### PR TITLE
Unregistered user sees strain show page

### DIFF
--- a/app/views/dispensaries/index.html.erb
+++ b/app/views/dispensaries/index.html.erb
@@ -20,14 +20,10 @@
         <td><%= dispensary.full_address %></td>
         <td><%= dispensary.email %></td>
         <td><%= dispensary.phone_number %></td>
-        <td><%= link_to 'Show', dispensary %></td>
-        <td><%= link_to 'Edit', edit_dispensary_path(dispensary) %></td>
-        <td><%= link_to 'Destroy', dispensary, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Must Be 18 Years Old to Enter', dispensary %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
 <br>
-
-<%= link_to 'New Dispensary', new_dispensary_path %>

--- a/app/views/dispensaries/show.html.erb
+++ b/app/views/dispensaries/show.html.erb
@@ -1,3 +1,5 @@
+<%= link_to 'Back', dispensaries_path %>
+
 <div class="header">
 <p id="notice"><%= notice %></p>
 <p>
@@ -23,21 +25,15 @@
 
 <div class="dispensary-strains">
   <strong>In Stock:</strong>
+  <ul>
     <% @dispensary.strains.each do |strain| %>
       <div class="strain">
-        <%= strain.strain %>
-        <%= strain.cannabinoid_abbreviation %>
-        <%= strain.cannabinoid %>
-        <%= strain.terpene %>
-        <%= strain.medical_use %>
-        <%= strain.health_benefit %>
-        <%= strain.category %>
-        <%= strain.strain_type %>
         <%= image_tag("https://img.sensiseeds.com/en/feminized-seeds/whitelabel/purple-bud-xl.jpg", size: '200') %>
+        <li>Name: <%= link_to strain.strain, strain_path(strain) %></li>
+        <li>Cannabinoid: <%= strain.cannabinoid_abbreviation %></li>
+        <li>Medical Use: <%= strain.medical_use %></li>
+        <li>Health Benefit: <%= strain.health_benefit %></li>
       </div>
     <% end %>
+  </ul>
 </div>
-
-
-
-<%= link_to 'Back', dispensary_path %>

--- a/app/views/dispensaries/show.html.erb
+++ b/app/views/dispensaries/show.html.erb
@@ -33,7 +33,7 @@
         <%= strain.health_benefit %>
         <%= strain.category %>
         <%= strain.strain_type %>
-        <%= strain.image %>
+        <%= image_tag("https://img.sensiseeds.com/en/feminized-seeds/whitelabel/purple-bud-xl.jpg", size: '200') %>
       </div>
     <% end %>
 </div>

--- a/app/views/strains/show.html.erb
+++ b/app/views/strains/show.html.erb
@@ -1,8 +1,9 @@
+<%= link_to 'Back', dispensary_path %>
 <p id="notice"><%= notice %></p>
 
 <p>
   <strong>Stain:</strong>
-  <%= @strain.stain %>
+  <%= @strain.strain %>
 </p>
 
 <p>
@@ -37,8 +38,11 @@
 
 <p>
   <strong>Type:</strong>
-  <%= @strain.type %>
+  <%= @strain.strain_type %>
 </p>
-
-<%= link_to 'Edit', edit_strain_path(@strain) %> |
-<%= link_to 'Back', strains_path %>
+<p>
+  <strong>Look at me!:</strong>
+  <ul>
+    <%= image_tag("https://img.sensiseeds.com/en/feminized-seeds/whitelabel/purple-bud-xl.jpg", size: '200') %>
+  </ul>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
 
-  root to: 'dispensaries#show'
-  
+  root to: 'dispensaries#index'
   resources :dispensaries, only: [:show]
   resources :strains, only: [:show]
   resources :users, only: [:edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   root to: 'dispensaries#index'
-  resources :dispensaries, only: [:show]
+  resources :dispensaries, only: [:index, :show]
   resources :strains, only: [:show]
   resources :users, only: [:edit, :update]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/spec/features/dispensary_show_spec.rb
+++ b/spec/features/dispensary_show_spec.rb
@@ -11,7 +11,15 @@ describe 'As an unregistered user' do
 
       expect(page).to have_content(dispensary.name)
       expect(page).to have_content(strains[0].strain)
+      expect(page).to have_content(strains[0].cannabinoid_abbreviation)
+      expect(page).to have_content(strains[0].medical_use)
+      expect(page).to have_content(strains[0].health_benefit)
+      # expect(page).to have_content(strains[0].image)
       expect(page).to have_content(strains[-1].strain)
+      expect(page).to have_content(strains[-1].cannabinoid_abbreviation)
+      expect(page).to have_content(strains[-1].medical_use)
+      expect(page).to have_content(strains[-1].health_benefit)
+      # expect(page).to have_content(strains[-1].image)
     end
   end
 end

--- a/spec/features/strain_show_spec.rb
+++ b/spec/features/strain_show_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe 'As an unregistered user' do
+  describe 'sees dispensary show page and clicks link to see strain info' do
+    it 'should take unregistered user to strain show page and show strain info' do
+      strains = create_list(:strain, 2)
+      dispensary = create(:dispensary)
+      dispensary.strains = strains
+
+      visit dispensary_path(dispensary)
+
+      click_on(strains[0].strain)
+
+      expect(current_path).to eq(strain_path(strains[0]))
+
+      expect(page).to have_content(strains[0].strain)
+      expect(page).to have_content(strains[0].cannabinoid)
+      expect(page).to have_content(strains[0].terpene)
+      expect(page).to have_content(strains[0].medical_use)
+      expect(page).to have_content(strains[0].health_benefit)
+      expect(page).to have_content(strains[0].category)
+      expect(page).to have_content(strains[0].strain_type)
+      # expect(page).to have_content(strains[0].image)
+    end
+  end
+end


### PR DESCRIPTION
closes #12

Adds:
Unregistered user can click strain name link and be taken to strain show page feature
Feature spec
Strain show view
